### PR TITLE
fix(help): Update help text for clarity and accuracy

### DIFF
--- a/utils/help.py
+++ b/utils/help.py
@@ -105,6 +105,7 @@ Common Utilities & Their Aliases:
   /command
   /config
   /dev
+  /docs
   /snapshot
   /tree
   /list
@@ -147,8 +148,8 @@ Configuration Files:
 
 Web-Based Configuration Manager:
   For an easy way to edit your user configuration files, run:
-  /utils config_manager --start
-  /utils config_manager --stop
+  /config --start
+  /config --stop
 """
 
 SECURITY_HELP = """


### PR DESCRIPTION
- Correct the /config command to show --start and --stop flags.

- Add the /docs command to the list of utilities.

- Removed incorrect references to internal dev scripts.