### PR TITLE
fix(config): Resolve UI bug in config manager

### DIFF
--- a/tools/config_manager/index.html
+++ b/tools/config_manager/index.html
@@ -647,6 +647,13 @@
                                         promptAccordionContent.appendChild(createFormElement('user_template', promptObject.user_template, [key, subKey], 'userConfig', `User prompt template for '${subKey}' AI role.`));
                                         const promptAccordion = createAccordionItem(subKey, promptAccordionContent, `prompts-accordion-${key}`, false);
                                         sectionContent.appendChild(promptAccordion);
+                                    } else if (key === 'ai_models' && typeof subValue === 'object' && subValue !== null) {
+                                        const modelObject = subValue;
+                                        const modelAccordionContent = document.createElement('div');
+                                        modelAccordionContent.classList.add('space-y-2', 'pl-2');
+                                        modelAccordionContent.appendChild(createFormElement('model', modelObject.model, [key, subKey], 'userConfig', `Model for '${subKey}' AI role.`));
+                                        const modelAccordion = createAccordionItem(subKey, modelAccordionContent, `ai_models-accordion-${key}`, true);
+                                        sectionContent.appendChild(modelAccordion);
                                     } else {
                                         sectionContent.appendChild(createFormElement(subKey, subValue, [key], 'userConfig', tooltip));
                                     }


### PR DESCRIPTION
A bug in the web-based configuration manager was causing the `ai_models` values to become corrupted. This was most noticeable with the `router` model.

The root cause was the generic way the UI was rendering object values. When loading a saved configuration, the UI would sometimes misinterpret the model data, leading to incorrect display and data corruption upon saving.

This fix introduces special handling for the `ai_models` section in the UIs rendering logic. It now creates a dedicated accordion and input field for each model, similar to how prompts are handled. This ensures the data is always displayed and managed correctly, preventing the corruption bug.