### PR TITLE
feat: Update router model and setup scripts

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -10,7 +10,7 @@
       "model": "herawen/lisa"
     },
     "router": {
-      "model": "herawen/lisa"
+      "model": "qwen3:0.6b"
     },
     "explainer": {
       "model": "herawen/lisa"

--- a/setup_scripts/setup_micro_X_mac.sh
+++ b/setup_scripts/setup_micro_X_mac.sh
@@ -106,11 +106,12 @@ echo ""
 # --- 4. Install Required Ollama Models ---
 echo "--- Installing Ollama Models (Requires Ollama application to be running) ---"
 if command_exists ollama; then
-    MODELS=(
-        "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
-        "herawen/lisa"
-        "nomic-embed-text"
-    )
+required_models=(
+    "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
+    "herawen/lisa"
+    "nomic-embed-text"
+    "qwen3:0.6b"
+)
     echo "Note: Pulling models can take a significant amount of time and storage."
     read -p "Do you want to proceed with pulling these models now? (y/N) " pull_models_choice
     if [[ "$pull_models_choice" =~ ^[Yy]$ ]]; then

--- a/setup_scripts/setup_micro_X_mint.sh
+++ b/setup_scripts/setup_micro_X_mint.sh
@@ -115,12 +115,12 @@ echo ""
 # --- 2. Install Required Ollama Models ---
 echo "--- Installing Ollama Models ---"
 if command_exists ollama; then
-    MODELS=(
-        "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
-        "vitali87/shell-commands-qwen2-1.5b-extended"
-        "herawen/lisa"
-    )
-    for model in "${MODELS[@]}"; do
+required_models=(
+    "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
+    "herawen/lisa"
+    "nomic-embed-text"
+    "qwen3:0.6b"
+)    for model in "${MODELS[@]}"; do
         echo "Pulling Ollama model: $model ..."
         ollama pull "$model"
         if ollama list | grep -q "${model%%:*}"; then

--- a/setup_scripts/setup_micro_X_termux.sh
+++ b/setup_scripts/setup_micro_X_termux.sh
@@ -92,11 +92,12 @@ echo ""
 # --- 3. Install Required Ollama Models ---
 echo "--- Installing Ollama Models (Requires Ollama server to be running) ---"
 if command_exists ollama; then
-    MODELS=(
-        "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
-        "vitali87/shell-commands-qwen2-1.5b-extended"
-        "herawen/lisa"
-    )
+required_models=(
+    "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
+    "herawen/lisa"
+    "nomic-embed-text"
+    "qwen3:0.6b"
+)
     echo "Note: Pulling models can take a significant amount of time and storage."
     echo "The models needed can total approximately 5GB."
     read -p "Do you want to proceed with pulling these models now? (y/N) " pull_models_choice

--- a/setup_scripts/setup_micro_X_wsl.sh
+++ b/setup_scripts/setup_micro_X_wsl.sh
@@ -93,10 +93,11 @@ echo ""
 # --- 3. Ollama Model Pulling - Instructions ---
 echo "--- Ollama Model Pulling (Instructions for Windows Host) ---"
 echo "The following Ollama models are required by micro_X:"
-MODELS=(
+required_models=(
     "vitali87/shell-commands-qwen2-1.5b-q8_0-extended"
-    "vitali87/shell-commands-qwen2-1.5b-extended"
     "herawen/lisa"
+    "nomic-embed-text"
+    "qwen3:0.6b"
 )
 echo "- ${MODELS[0]}"
 echo "- ${MODELS[1]}"


### PR DESCRIPTION
This commit introduces the following changes:

- Updates the router model to `qwen3:0.6b` in the default configuration.
- Adds the new router model to the setup scripts to ensure it is pulled during setup.
- Removes the unused `vitali87/shell-commands-qwen2-1.5b-extended` model from the setup scripts.