### PR TITLE
feat: Make /dev utility branch-agnostic

### DIFF
--- a/config/default_aliases.json
+++ b/config/default_aliases.json
@@ -2,7 +2,7 @@
   "/alias": "/utils alias",
   "/command": "/utils command",
   "/config": "/utils config_manager",
-  "/dev": "python utils/dev.py",
+  "/dev": "/utils dev",
   "/docs": "python utils/docs.py",
   "/docs --help": "python utils/docs.py --help",
   "/docs --lynx": "python utils/docs.py --lynx",


### PR DESCRIPTION
This commit refactors the /dev utility to be branch-agnostic, allowing it to be run from any branch (`main`, `testing`, or `dev`) and correctly target the other branches.

- Implements a new `find_environment_root` function that robustly locates the multi-branch environment root.
- Updates all pathing logic in `utils/dev.py` to use the new environment root.
- Centralizes snapshot outputs to a common `snapshots` directory at the environment root.
- Updates the `/dev` alias in `config/default_aliases.json` to be consistent with other utility aliases.