### PR TITLE
feat(knowledge): implement multi-kb RAG utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,7 @@ micro_X-dev/
 
 *.code-workspace
 gemini_startup_prompt.txt
+
+# Knowledge base files
+knowledge_bases/
+knowledge_base/

--- a/config/default_aliases.json
+++ b/config/default_aliases.json
@@ -7,6 +7,7 @@
   "/docs --help": "python utils/docs.py --help",
   "/docs --lynx": "python utils/docs.py --lynx",
   "/help": "/utils help",
+  "/knowledge": "/utils knowledge",
   "/list": "/utils list_scripts",
   "/ollama": "/utils ollama_cli",
   "/snapshot": "/utils generate_snapshot",

--- a/modules/intent_tools.py
+++ b/modules/intent_tools.py
@@ -107,6 +107,43 @@ def remove_alias(alias_name: str) -> str:
     return f'/utils alias --remove {alias_name}'
 
 
+@tool
+def query_knowledge_base(query: str, kb_name: str = "default") -> str:
+    """
+    Use this tool to answer questions using a user-curated knowledge base.
+    If the user's query mentions a specific knowledge base, provide its name using the 'kb_name' parameter.
+    The input must be the user's full question.
+    """
+    return f'/knowledge --name {kb_name} query "{query}"'
+
+
+@tool
+def add_file_to_knowledge_base(path: str, kb_name: str = "default") -> str:
+    """
+    Use this tool to add a local file to a specified knowledge base.
+    The user must provide the path to the file. If they specify a knowledge base name, pass it as 'kb_name'.
+    For example: 'add the file /path/to/my/doc.md to the my_kb knowledge base'.
+    """
+    return f'/knowledge --name {kb_name} add-file {path}'
+
+
+@tool
+def add_url_to_knowledge_base(url: str, kb_name: str = "default", recursive: bool = False, depth: int = 1, save_cache: bool = False) -> str:
+    """
+    Use this tool to add content from a URL to a specified knowledge base.
+    The user must provide the URL. If they specify a knowledge base name, pass it as 'kb_name'.
+    Set 'recursive' to True or specify a 'depth' greater than 1 to crawl the website.
+    Set 'save_cache' to True to keep a local copy of the downloaded pages.
+    """
+    command = f'/knowledge --name {kb_name} add-url {url}'
+    # A depth > 1 implies recursion.
+    if recursive or depth > 1:
+        command += f' --recursive --depth {depth}'
+    if save_cache:
+        command += ' --save-cache'
+    return command
+
+
 def get_all_tools():
     """Returns a list of all defined intent tools."""
     return [
@@ -121,4 +158,7 @@ def get_all_tools():
         move_command_to_category,
         add_alias,
         remove_alias,
+        query_knowledge_base,
+        add_file_to_knowledge_base,
+        add_url_to_knowledge_base,
     ]

--- a/modules/rag_manager.py
+++ b/modules/rag_manager.py
@@ -1,0 +1,198 @@
+# modules/rag_manager.py
+import logging
+import os
+from langchain_chroma import Chroma
+from langchain_ollama.embeddings import OllamaEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import (
+    TextLoader,
+    PyPDFLoader,
+    BSHTMLLoader,
+    UnstructuredURLLoader,
+)
+from langchain_community.document_loaders.recursive_url_loader import RecursiveUrlLoader
+from bs4 import BeautifulSoup as Soup
+import requests
+from urllib.parse import urljoin, urlparse
+
+logger = logging.getLogger(__name__)
+
+class RAGManager:
+    def __init__(self, config: dict, name: str = "default"):
+        self.config = config
+        self.name = name
+        self.vector_store = None
+        self.embedding_model_name = None
+        self.embeddings = None
+        self.text_splitter = None
+
+        # All paths are now relative to a name-specific directory
+        base_path = os.path.join(os.getcwd(), "knowledge_bases", self.name)
+        self._db_path = base_path
+        self._cache_path = os.path.join(base_path, "cache")
+        self._collection_name = f"microx_rag_{self.name}"
+
+    def initialize(self):
+        """Initializes the RAG manager, database, and collection."""
+        logger.info("Initializing RAGManager...")
+        try:
+            # 1. Get embedding model from config
+            self.embedding_model_name = self.config.get('intent_classification', {}).get('embedding_model')
+            if not self.embedding_model_name:
+                logger.error("Embedding model not specified in config. Cannot initialize RAGManager.")
+                return
+            self.embeddings = OllamaEmbeddings(model=self.embedding_model_name)
+
+            # 2. Initialize Chroma vector store with LangChain wrapper
+            self.vector_store = Chroma(
+                collection_name=self._collection_name,
+                embedding_function=self.embeddings,
+                persist_directory=self._db_path,
+            )
+            logger.debug(f"self.vector_store object after init: {self.vector_store}")
+
+            # 3. Initialize text splitter
+            self.text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=1000,
+                chunk_overlap=200,
+            )
+
+            os.makedirs(self._cache_path, exist_ok=True)
+
+            logger.info(f"RAGManager initialized successfully. DB path: '{self._db_path}', Collection: '{self._collection_name}'")
+
+        except Exception as e:
+            logger.error(f"Failed to initialize RAGManager: {e}", exc_info=True)
+
+    def add_file(self, file_path: str):
+        """Adds a single file to the knowledge base."""
+        if not self.vector_store:
+            logger.error("RAG vector store not initialized. Cannot add file.")
+            return
+        
+        logger.info(f"Processing file: {file_path}")
+        try:
+            if file_path.endswith(".pdf"):
+                loader = PyPDFLoader(file_path)
+            elif file_path.endswith((".html", ".htm")):
+                loader = BSHTMLLoader(file_path, bs_kwargs={'features': 'html.parser'})
+            else: # Default to text loader for .txt, .md, .py, etc.
+                loader = TextLoader(file_path, encoding="utf-8")
+            
+            documents = loader.load()
+            chunks = self.text_splitter.split_documents(documents)
+            
+            self.vector_store.add_documents(chunks)
+            logger.info(f"Successfully added {len(chunks)} chunks from {file_path} to the knowledge base.")
+
+        except Exception as e:
+            logger.error(f"Failed to add file {file_path}: {e}", exc_info=True)
+
+    def add_directory(self, dir_path: str):
+        """Recursively adds all supported files in a directory."""
+        if not self.vector_store:
+            logger.error("RAG vector store not initialized. Cannot add directory.")
+            return
+
+        logger.info(f"Processing directory: {dir_path}")
+        # This is a simplified approach. A more robust solution would iterate
+        # and use the specific loaders from add_file.
+        try:
+            # Find all files, then load them one by one
+            for root, _, files in os.walk(dir_path):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    self.add_file(file_path) # Reuse the single file logic
+
+            logger.info(f"Finished processing directory {dir_path}.")
+
+        except Exception as e:
+            logger.error(f"Failed to process directory {dir_path}: {e}", exc_info=True)
+
+
+    def _url_to_filename(self, url: str) -> str:
+        """Converts a URL to a safe filename for caching."""
+        parsed_url = urlparse(url)
+        # Combine netloc and path, replacing slashes
+        filename = f"{parsed_url.netloc}{parsed_url.path}".replace('/', '_').replace('\\', '_')
+        # Ensure it doesn't end with an underscore if it was a directory
+        if filename.endswith('_'):
+            filename += "index.html"
+        if not os.path.splitext(filename)[1]:
+            filename += ".html"
+        return os.path.join(self._cache_path, filename)
+
+    def add_url(self, url: str, recursive: bool = False, save_cache: bool = False, depth: int = 2):
+        """Fetches a URL and adds its content to the knowledge base."""
+        if not self.vector_store:
+            logger.error("RAG vector store not initialized. Cannot add URL.")
+            return
+
+        urls_to_visit = {url}
+        visited_urls = set()
+        max_depth = depth if recursive else 1
+
+        for depth in range(max_depth):
+            if not urls_to_visit:
+                break
+            
+            current_urls = list(urls_to_visit)
+            urls_to_visit.clear()
+            
+            for current_url in current_urls:
+                if current_url in visited_urls:
+                    continue
+                
+                logger.info(f"Processing URL (Depth: {depth}): {current_url}")
+                visited_urls.add(current_url)
+
+                try:
+                    headers = {
+                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+                    }
+                    response = requests.get(current_url, timeout=10, headers=headers)
+                    response.raise_for_status()
+                    html_content = response.text
+
+                    if save_cache:
+                        cache_path = self._url_to_filename(current_url)
+                        with open(cache_path, 'w', encoding='utf-8') as f:
+                            f.write(html_content)
+                        logger.info(f"Saved page to cache: {cache_path}")
+
+                    soup = Soup(html_content, "html.parser")
+                    text_content = soup.get_text(separator=' ', strip=True)
+
+                    if text_content:
+                        chunks = self.text_splitter.split_text(text_content)
+                        self.vector_store.add_texts(texts=chunks, metadatas=[{'source': current_url}] * len(chunks))
+                        logger.info(f"Added {len(chunks)} chunks from {current_url}.")
+
+                    if recursive and depth < max_depth - 1:
+                        for link in soup.find_all('a', href=True):
+                            absolute_link = urljoin(current_url, link['href'])
+                            if urlparse(absolute_link).scheme in ['http', 'https']:
+                                urls_to_visit.add(absolute_link)
+
+                except requests.RequestException as e:
+                    logger.warning(f"Failed to download URL {current_url}: {e}")
+                except Exception as e:
+                    logger.error(f"Failed to process URL {current_url}: {e}", exc_info=True)
+
+
+    def query(self, query_text: str, n_results: int = 5) -> list[str]:
+        """
+        Queries the knowledge base and returns the most relevant document chunks.
+        """
+        if not self.vector_store:
+            logger.error("RAG vector store not initialized. Cannot query.")
+            return []
+
+        try:
+            results = self.vector_store.similarity_search(query_text, k=n_results)
+            # Extract the page content from the Document objects
+            return [doc.page_content for doc in results]
+        except Exception as e:
+            logger.error(f"Failed to query the knowledge base: {e}", exc_info=True)
+            return []
+

--- a/modules/router_agent.py
+++ b/modules/router_agent.py
@@ -47,7 +47,7 @@ def create_router_agent(config: dict):
     agent_executor = AgentExecutor(
         agent=agent,
         tools=tools,
-        verbose=True, # Keep verbose for now to confirm it works
+        verbose=False, # Keep verbose for now to confirm it works
         handle_parsing_errors=True,
         return_intermediate_steps=True # This is the crucial change
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ langchain-core>=0.1.0
 langchain-community>=0.0.1
 langgraph>=0.0.1
 langchain-ollama>=0.0.1
+chromadb>=0.4.24
+beautifulsoup4>=4.12.3
+langchain-chroma>=0.1.0

--- a/utils/help.py
+++ b/utils/help.py
@@ -32,6 +32,7 @@ Common Commands:
   /command            - Manage command categorizations.
   /config             - Opens a web UI to manage your configuration.
   /snapshot           - Creates a snapshot of the project for context sharing.
+  /knowledge          - Manages and queries the local RAG knowledge base.
   /tree               - Generates a file showing the project structure.
   /docs               - Opens the project documentation in a web browser.
   /test               - Runs the project's test suite.
@@ -44,7 +45,7 @@ Common Commands:
 
 For more details on a specific feature, use '/help <topic>'.
 Available Topics:
-  ai, alias, command, config, dev, install_requirements, keybindings, list, security, snapshot, utilities
+  ai, alias, command, config, dev, install_requirements, keybindings, knowledge, list, security, snapshot, utilities
 """
 
 AI_HELP = """
@@ -130,7 +131,7 @@ def main():
         print(GENERAL_HELP)
     elif topic == 'ai':
         print(AI_HELP)
-    elif topic in ('alias', 'command', 'config', 'dev', 'docs', 'install_requirements', 'list', 'snapshot', 'utilities'):
+    elif topic in ('alias', 'command', 'config', 'dev', 'docs', 'install_requirements', 'knowledge', 'list', 'snapshot', 'utilities'):
         module_name = {
             'alias': 'alias.py',
             'command': 'command.py',
@@ -138,6 +139,7 @@ def main():
             'dev': 'dev.py',
             'docs': 'docs.py',
             'install_requirements': 'install_requirements.py',
+            'knowledge': 'knowledge.py',
             'list': 'list_scripts.py',
             'snapshot': 'generate_snapshot.py',
             'utilities': 'docs.py'

--- a/utils/knowledge.py
+++ b/utils/knowledge.py
@@ -1,0 +1,197 @@
+# utils/knowledge.py
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+
+# Add project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from modules.rag_manager import RAGManager
+from modules import config_handler
+from langchain_ollama.llms import OllamaLLM
+from langchain_core.prompts import ChatPromptTemplate
+
+# --- Logging Setup ---
+logger = logging.getLogger(__name__)
+
+# --- Helper Functions ---
+
+def merge_configs(base, override):
+    """ Helper function to recursively merge dictionaries. """
+    merged = base.copy()
+    for key, value in override.items():
+        if isinstance(value, dict) and key in merged and isinstance(merged[key], dict):
+            merged[key] = merge_configs(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+def load_config():
+    """Loads the main application configuration."""
+    SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+    CONFIG_DIR = os.path.join(os.path.dirname(SCRIPT_DIR), 'config')
+    DEFAULT_CONFIG_FILENAME = "default_config.json"
+    USER_CONFIG_FILENAME = "user_config.json"
+
+    default_config_path = os.path.join(CONFIG_DIR, DEFAULT_CONFIG_FILENAME)
+    user_config_path = os.path.join(CONFIG_DIR, USER_CONFIG_FILENAME)
+
+    config = config_handler.load_jsonc_file(default_config_path)
+    if config is None:
+        logger.error("CRITICAL: Default configuration not found. Exiting.")
+        sys.exit(1)
+
+    user_settings = config_handler.load_jsonc_file(user_config_path)
+    if user_settings:
+        config = merge_configs(config, user_settings)
+
+    return config
+
+async def get_rag_response(rag_manager: RAGManager, query: str, llm: OllamaLLM) -> str:
+    """Retrieves context from RAG and generates a response using an LLM."""
+    context_chunks = rag_manager.query(query, n_results=5)
+
+    if not context_chunks:
+        return "I could not find any relevant information in the knowledge base to answer your question."
+
+    context = "\n\n---\n\n".join(context_chunks)
+
+    template = """
+    You are an assistant for question-answering tasks.
+    Use the following pieces of retrieved context to answer the question.
+    If you don't know the answer, just say that you don't know.
+    Keep the answer concise and relevant.
+    Do not include your thinking process or any XML-style tags like <think> in your final response.
+
+    Context:
+    {context}
+
+    Question: {question}
+
+    Answer:
+    """
+    prompt = ChatPromptTemplate.from_template(template)
+
+    chain = prompt | llm
+
+    raw_response = await chain.ainvoke({"context": context, "question": query})
+    
+    # Programmatically strip the <think> block as a fallback
+    clean_response = re.sub(r"<think>.*?</think>", "", raw_response, flags=re.DOTALL).strip()
+    
+    return clean_response
+
+# --- Help Text ---
+HELP_TEXT = """
+micro_X Knowledge Base Utility
+
+Usage: /knowledge [--name <kb_name>] <command> [options] [-q]
+
+Options:
+  --name <kb_name>    Specify the knowledge base to use (defaults to 'default').
+
+Commands:
+  query <text>        Ask a question to the knowledge base.
+  add-file <path>     Add a local file to the knowledge base. Path must be absolute.
+  add-dir <path>      Recursively add all supported files in a local directory. Path must be absolute.
+  add-url <url> [--recursive] [--save-cache] [--depth N]      Add content from a URL to the knowledge base.
+
+Description:
+  This utility manages a local vector knowledge base for Retrieval-Augmented Generation (RAG).
+  You can add documents from local files, directories, or web pages. Once added, you can
+  query the knowledge base using natural language.
+"""
+
+# --- Main Execution --- 
+async def main():
+    class HelpAction(argparse.Action):
+        def __init__(self, option_strings, dest, **kwargs):
+            super(HelpAction, self).__init__(option_strings, dest, nargs=0, **kwargs)
+        def __call__(self, parser, namespace, values, option_string=None):
+            print(HELP_TEXT)
+            parser.exit()
+
+    # --- Two-Pass Parser Setup ---
+    # This allows global flags like --name to be used before or after the command.
+
+    # 1. Define a parser for global arguments
+    global_parser = argparse.ArgumentParser(add_help=False)
+    global_parser.add_argument('-q', '--quiet', action='store_true', help='Suppress informational output.')
+    global_parser.add_argument('--name', type=str, default='default', help='Specify the name of the knowledge base to use.')
+    
+    # 2. Parse the known global args, and leave the rest for the command parser
+    global_args, remaining_argv = global_parser.parse_known_args()
+
+    # 3. Define the main parser and subparsers for commands
+    parser = argparse.ArgumentParser(
+        description="Manage and query the micro_X knowledge base.",
+        add_help=False
+    )
+    parser.add_argument('-h', '--help', action=HelpAction, help='show this help message and exit')
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Command: add-file
+    parser_add_file = subparsers.add_parser("add-file", help="Add a single file to the knowledge base.")
+    parser_add_file.add_argument("path", type=str, help="The absolute path to the file.")
+
+    # Command: add-dir
+    parser_add_dir = subparsers.add_parser("add-dir", help="Add all files in a directory to the knowledge base.")
+    parser_add_dir.add_argument("path", type=str, help="The absolute path to the directory.")
+
+    # Command: add-url
+    parser_add_url = subparsers.add_parser("add-url", help="Add a URL to the knowledge base.")
+    parser_add_url.add_argument("url", type=str, help="The URL to process.")
+    parser_add_url.add_argument("--recursive", action="store_true", help="Enable recursive crawling of links (depth: 2).")
+    parser_add_url.add_argument("--save-cache", action="store_true", help="Save the raw HTML content of crawled pages to a cache directory.")
+    parser_add_url.add_argument("--depth", type=int, default=2, help="Set the maximum depth for recursive crawling. Default is 2.")
+
+    # Command: query
+    parser_query = subparsers.add_parser("query", help="Query the knowledge base.")
+    parser_query.add_argument("query_text", type=str, help="The question to ask.")
+
+    # 4. Check if a command was provided. If not, print help.
+    if not remaining_argv or remaining_argv[0] not in subparsers.choices.keys():
+        print(HELP_TEXT)
+        sys.exit(0)
+
+    # 5. Parse the remaining args for the command, merging them into the global_args namespace
+    args = parser.parse_args(remaining_argv, namespace=global_args)
+
+    # --- Logging Configuration ---
+    log_level = logging.WARNING if args.quiet else logging.INFO
+    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    # --- Initialization ---
+    config = load_config()
+    rag_manager = RAGManager(config, name=args.name)
+    rag_manager.initialize()
+
+    llm_model_name = config.get('ai_models', {}).get('router', {}).get('model', 'herawen/lisa')
+    llm = OllamaLLM(model=llm_model_name)
+
+    # --- Command Handling ---
+    if args.command == "add-file":
+        if os.path.isabs(args.path):
+            rag_manager.add_file(args.path)
+        else:
+            logger.error(f"Path '{args.path}' is not absolute. Please provide an absolute path.")
+
+    elif args.command == "add-dir":
+        if os.path.isabs(args.path):
+            rag_manager.add_directory(args.path)
+        else:
+            logger.error(f"Path '{args.path}' is not absolute. Please provide an absolute path.")
+
+    elif args.command == "add-url":
+        rag_manager.add_url(args.url, recursive=args.recursive, save_cache=args.save_cache, depth=args.depth)
+
+    elif args.command == "query":
+        response = await get_rag_response(rag_manager, args.query_text, llm)
+        print("\nResponse:")
+        print(response)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Implements a new Retrieval-Augmented Generation (RAG) system, allowing users to create and query multiple, named knowledge bases.

This new feature is exposed through the /knowledge utility, which includes the following sub-commands:

- query: Ask a question to a specified knowledge base.

- add-file: Add a local file.

- add-dir: Recursively add files from a local directory.

- add-url: Add content from a URL.

The add-url command supports recursive crawling with configurable depth (--depth) and optional caching of downloaded pages (--save-cache).

The entire feature is integrated with the AI router, allowing for natural language interaction to query, add files, and add URLs to specific knowledge bases.

This commit also includes:

- A new /knowledge alias.

- Updates to the main help utility to include the new feature.

- New dependencies (chromadb, beautifulsoup4, langchain-chroma) in requirements.txt.

- An update to .gitignore to exclude the generated knowledge_bases/ directory.