### PR TITLE
fix(knowledge): improve crawler robustness and parser flexibility

### DIFF
--- a/modules/rag_manager.py
+++ b/modules/rag_manager.py
@@ -150,6 +150,17 @@ class RAGManager:
                     headers = {
                         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
                     }
+
+                    # First, send a HEAD request to check the content type
+                    head_response = requests.head(current_url, timeout=5, allow_redirects=True, headers=headers)
+                    head_response.raise_for_status()
+                    content_type = head_response.headers.get('Content-Type', '')
+
+                    if 'text/html' not in content_type:
+                        logger.info(f"Skipping non-HTML URL: {current_url} (Content-Type: {content_type})")
+                        continue
+
+                    # If content type is valid, proceed with GET request
                     response = requests.get(current_url, timeout=10, headers=headers)
                     response.raise_for_status()
                     html_content = response.text

--- a/utils/knowledge.py
+++ b/utils/knowledge.py
@@ -154,8 +154,10 @@ async def main():
 
     # 4. Check if a command was provided. If not, print help.
     if not remaining_argv or remaining_argv[0] not in subparsers.choices.keys():
-        print(HELP_TEXT)
-        sys.exit(0)
+        # Also handle the case where only -h is passed after global args
+        if not remaining_argv or remaining_argv == ['--help'] or remaining_argv == ['-h']:
+             print(HELP_TEXT)
+             sys.exit(0)
 
     # 5. Parse the remaining args for the command, merging them into the global_args namespace
     args = parser.parse_args(remaining_argv, namespace=global_args)


### PR DESCRIPTION
The URL crawler now sends a HEAD request to check the Content-Type before downloading, preventing it from processing non-HTML files.

The argument parser for the /knowledge utility now uses a two-pass approach, allowing global flags (like --name) to be specified in any order.