### PR TITLE
test: Significant coverage boost for ollama_manager and config_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the **micro_X** project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1042] - 2026-01-26
+### Added
+- **Testing:** Significantly improved test coverage for `modules/ollama_manager.py` (from 39% to 71%), adding scenarios for error handling, service management, and edge cases.
+- **Testing:** Added `tests/test_utils_config_manager.py`, raising coverage for `utils/config_manager.py` from 0% to 63%.
+
+## [0.0.1041] - 2026-01-26
+### Added
+- **Testing:** Added `tests/test_utils_version_sync.py` to cover the version synchronization utility.
+- **Testing:** Integrated `pytest-cov` into `requirements.txt` for automated code coverage reporting.
+
 ## [0.0.1040] - 2026-01-26
 ### Added
 - **Testing:** Massive expansion of test coverage, reaching **322 unit tests**.

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -1,6 +1,6 @@
 {
   "application": {
-    "version": "0.0.1041"
+    "version": "0.0.1042"
   },
   "ai_models": {
     "primary_translator": {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,8 @@ project = 'micro_X'
 copyright = '2025, micro_X Team'
 author = 'micro_X Team'
 
-version = '0.0.1041'
-release = '0.0.1041'
+version = '0.0.1042'
+release = '0.0.1042'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/micro_X-A_Technical_Whitepaper.md
+++ b/micro_X-A_Technical_Whitepaper.md
@@ -2,7 +2,7 @@
 
 ### **A Technical Whitepaper**
 
-Version: 0.0.1041 (Reflecting Deep Analysis of Snapshot 2025-08-20)  
+Version: 0.0.1042 (Reflecting Deep Analysis of Snapshot 2025-08-20)  
 Project Repository: https://github.com/thurtz/micro_X.git
 
 ### **Abstract**

--- a/micro_X.desktop
+++ b/micro_X.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.0.1041
+Version=0.0.1042
 Type=Application
 #Name=micro_X
 Comment=Launch micro_X AI Shell inside tmux

--- a/tests/test_ollama_manager.py
+++ b/tests/test_ollama_manager.py
@@ -111,3 +111,118 @@ async def test_set_ollama_host_from_config(mock_config):
     with patch.dict(os.environ, {}, clear=True):
         ollama_manager.set_ollama_host_from_config(mock_config)
         assert os.environ['OLLAMA_HOST'] == 'http://localhost:11434'
+
+def test_set_ollama_host_formatting(mock_config):
+    # Test host without scheme
+    mock_config['ollama_service']['ollama_host'] = "127.0.0.1"
+    with patch.dict(os.environ, {}, clear=True):
+        ollama_manager.set_ollama_host_from_config(mock_config)
+        assert os.environ['OLLAMA_HOST'] == 'http://127.0.0.1:11434'
+
+@pytest.mark.asyncio
+async def test_find_ollama_executable_not_initialized(mock_ui_append):
+    ollama_manager._is_initialized = False
+    assert await ollama_manager._find_ollama_executable() is None
+
+@pytest.mark.asyncio
+async def test_find_ollama_executable_fallback(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    # Configured path invalid, system path valid
+    mock_config['ollama_service']['executable_path'] = "/invalid/path"
+    
+    with patch('shutil.which') as mock_which:
+        def side_effect(path):
+            if path == "/invalid/path": return None
+            if path == "ollama": return "/usr/bin/ollama"
+            return None
+        mock_which.side_effect = side_effect
+        
+        assert await ollama_manager._find_ollama_executable() == "/usr/bin/ollama"
+
+@pytest.mark.asyncio
+async def test_find_ollama_executable_none(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    mock_config['ollama_service']['executable_path'] = None
+    with patch('shutil.which', return_value=None):
+        assert await ollama_manager._find_ollama_executable() is None
+        mock_ui_append.assert_any_call("❌ Ollama executable ('ollama') not found in your system PATH.", style_class='error')
+
+@pytest.mark.asyncio
+async def test_is_ollama_server_running_errors(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    
+    # RequestError
+    with patch('asyncio.to_thread', side_effect=ollama.RequestError("Connection refused")):
+        assert await ollama_manager.is_ollama_server_running() is False
+        
+    # General Exception
+    with patch('asyncio.to_thread', side_effect=Exception("Boom")):
+        assert await ollama_manager.is_ollama_server_running() is False
+        mock_ui_append.assert_any_call("⚠️ Error checking Ollama status: Boom", style_class='warning')
+
+@pytest.mark.asyncio
+async def test_launch_ollama_serve_errors(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    # Mock find executable success
+    ollama_manager._ollama_exe_path_cached = "/bin/ollama"
+    
+    # Tmux missing
+    with patch('shutil.which', return_value=None):
+        assert await ollama_manager._launch_ollama_serve_in_tmux() is False
+        mock_ui_append.assert_any_call("❌ tmux not found. Cannot automatically start 'ollama serve'.", style_class='error')
+
+    # Launch failure (CalledProcessError)
+    with patch('shutil.which', return_value='/bin/tmux'), \
+         patch('modules.ollama_manager._is_tmux_session_running', new_callable=AsyncMock, return_value=False), \
+         patch('asyncio.to_thread', side_effect=subprocess.CalledProcessError(1, "cmd", stderr="Start failed")):
+        
+        assert await ollama_manager._launch_ollama_serve_in_tmux() is False
+        # Use str(c) to check call args content loosely or assert_any_call if exact match known
+        calls = [str(c) for c in mock_ui_append.call_args_list]
+        assert any("Start failed" in c for c in calls)
+
+@pytest.mark.asyncio
+async def test_wait_for_server_readiness_failure(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    mock_config['ollama_service']['server_check_retries'] = 2
+    mock_config['ollama_service']['server_check_interval_seconds'] = 0.01
+    
+    with patch('modules.ollama_manager.is_ollama_server_running', new_callable=AsyncMock, return_value=False):
+        assert await ollama_manager._wait_for_server_readiness() is False
+        mock_ui_append.assert_any_call("❌ Ollama server did not become responsive in time.", style_class='error')
+
+@pytest.mark.asyncio
+async def test_explicit_stop_errors(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    
+    # Tmux missing
+    with patch('shutil.which', return_value=None):
+        assert await ollama_manager.explicit_stop_ollama_service(mock_config, mock_ui_append) is False
+        
+    # Kill failure
+    with patch('shutil.which', return_value='/bin/tmux'), \
+         patch('modules.ollama_manager._is_tmux_session_running', new_callable=AsyncMock, return_value=True), \
+         patch('asyncio.to_thread', side_effect=subprocess.CalledProcessError(1, "kill", stderr="Kill failed")):
+         
+        assert await ollama_manager.explicit_stop_ollama_service(mock_config, mock_ui_append) is False
+        calls = [str(c) for c in mock_ui_append.call_args_list]
+        assert any("Kill failed" in c for c in calls)
+
+@pytest.mark.asyncio
+async def test_explicit_restart_success(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    
+    with patch('modules.ollama_manager.explicit_stop_ollama_service', new_callable=AsyncMock, return_value=True) as mock_stop, \
+         patch('modules.ollama_manager.explicit_start_ollama_service', new_callable=AsyncMock, return_value=True) as mock_start:
+         
+         assert await ollama_manager.explicit_restart_ollama_service(mock_config, mock_ui_append) is True
+         mock_stop.assert_awaited_once()
+         mock_start.assert_awaited_once()
+
+@pytest.mark.asyncio
+async def test_explicit_restart_fail_stop(mock_config, mock_ui_append):
+    setup_manager(mock_config, mock_ui_append)
+    
+    with patch('modules.ollama_manager.explicit_stop_ollama_service', new_callable=AsyncMock, return_value=False):
+         assert await ollama_manager.explicit_restart_ollama_service(mock_config, mock_ui_append) is False
+         mock_ui_append.assert_any_call("❌ Restart aborted because stopping the service failed critically.", style_class='error')

--- a/tests/test_utils_config_manager.py
+++ b/tests/test_utils_config_manager.py
@@ -1,0 +1,158 @@
+# tests/test_utils_config_manager.py
+
+import pytest
+import os
+import json
+import socket
+import tempfile
+from unittest.mock import MagicMock, patch, mock_open
+from utils import config_manager
+import subprocess
+import sys
+
+# --- Helper Tests ---
+def test_sanitize_branch_name():
+    assert config_manager.sanitize_branch_name_for_tmux("feature/new-ui") == "feature_new-ui"
+    assert config_manager.sanitize_branch_name_for_tmux("main") == "main"
+    assert config_manager.sanitize_branch_name_for_tmux("user@host:branch") == "user_host_branch"
+
+def test_get_preferred_port():
+    base = 8000
+    assert config_manager.get_preferred_port_for_branch("main", base) == 8000
+    assert config_manager.get_preferred_port_for_branch("dev", base) == 8001
+    assert config_manager.get_preferred_port_for_branch("testing", base) == 8002
+    # Check that other branches get a deterministic offset
+    other_port = config_manager.get_preferred_port_for_branch("feature-x", base)
+    assert 8010 <= other_port <= 8019
+
+def test_get_dynamic_tmux_session_name():
+    name = config_manager.get_dynamic_tmux_session_name("dev")
+    assert name == "microx_config_server_session_dev"
+
+# --- HTTP Handler Tests ---
+@pytest.fixture
+def mock_request_handler():
+    # Helper to instantiate the handler with mocked request/client_address/server
+    def _create_handler(request_body, path):
+        request = MagicMock()
+        client_address = ('127.0.0.1', 12345)
+        server = MagicMock()
+        
+        # Mock the rfile (read stream)
+        request.makefile.return_value.read.return_value = request_body.encode('utf-8')
+        # We need to mock rfile on the handler instance itself because SimpleHTTPRequestHandler uses it
+        
+        # We'll patch SimpleHTTPRequestHandler's __init__ to avoid socket setup
+        with patch('http.server.SimpleHTTPRequestHandler.__init__', return_value=None) as mock_init:
+            handler = config_manager.ConfigManagerHTTPRequestHandler(request, client_address, server)
+            # Manually set attributes normally set by __init__ or parse_request
+            handler.client_address = client_address
+            handler.path = path
+            handler.command = "POST"
+            handler.request_version = "HTTP/1.1"
+            handler.requestline = f"POST {path} HTTP/1.1"
+            handler.close_connection = True
+            handler.headers = {'Content-Length': str(len(request_body))}
+            handler.rfile = MagicMock()
+            handler.rfile.read.return_value = request_body.encode('utf-8')
+            handler.wfile = MagicMock()
+            handler.send_response = MagicMock()
+            return handler
+    return _create_handler
+
+def test_do_post_save_user_config(mock_request_handler):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_manager.ConfigManagerHTTPRequestHandler.PROJECT_ROOT_PATH = tmpdir
+        
+        data = {"theme": "dark"}
+        handler = mock_request_handler(json.dumps(data), '/api/save/user_config')
+        
+        handler.do_POST()
+        
+        # Check response code (we mock send_response)
+        handler.send_response.assert_called_with(200)
+        
+        # Verify file written
+        expected_path = os.path.join(tmpdir, "config", "user_config.json")
+        assert os.path.exists(expected_path)
+        with open(expected_path, 'r') as f:
+            saved_data = json.load(f)
+        assert saved_data == data
+
+def test_do_post_invalid_json(mock_request_handler):
+    handler = mock_request_handler("{invalid-json", '/api/save/user_config')
+    handler.do_POST()
+    handler.send_response.assert_called_with(400)
+
+def test_do_post_invalid_endpoint(mock_request_handler):
+    handler = mock_request_handler("{}", '/api/save/unknown')
+    handler.do_POST()
+    handler.send_response.assert_called_with(404)
+
+# --- Server Management Tests ---
+@patch("subprocess.run")
+def test_is_tmux_session_running(mock_run):
+    # Case: Running
+    mock_run.return_value.returncode = 0
+    assert config_manager.is_tmux_session_running("sess") is True
+    
+    # Case: Not running
+    mock_run.return_value.returncode = 1
+    assert config_manager.is_tmux_session_running("sess") is False
+    
+    # Case: Tmux missing
+    mock_run.side_effect = FileNotFoundError
+    assert config_manager.is_tmux_session_running("sess") is False
+
+@patch("utils.config_manager.is_tmux_session_running")
+@patch("subprocess.run")
+@patch("webbrowser.open_new_tab")
+@patch("utils.config_manager.find_free_port")
+@patch("time.sleep") # Speed up test
+def test_start_server_in_tmux_new(mock_sleep, mock_find_port, mock_browser, mock_run, mock_is_running):
+    # Setup
+    mock_is_running.return_value = False # Not running
+    mock_find_port.return_value = 8123
+    
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create the HTML file so the check passes
+        os.makedirs(os.path.join(tmpdir, "tools", "config_manager"), exist_ok=True)
+        with open(os.path.join(tmpdir, "tools", "config_manager", "index.html"), 'w') as f:
+            f.write("<html></html>")
+            
+        config_manager.start_server_in_tmux(8000, tmpdir, "dev")
+        
+        # Verify tmux command
+        assert mock_run.called
+        args = mock_run.call_args[0][0]
+        assert args[0] == "tmux"
+        assert args[1] == "new-session"
+        assert "microx_config_server_session_dev" in args
+        
+        # Verify browser opened
+        mock_browser.assert_called_with("http://localhost:8123/tools/config_manager/index.html")
+
+@patch("utils.config_manager.is_tmux_session_running")
+@patch("subprocess.run")
+def test_stop_server_tmux_session(mock_run, mock_is_running):
+    mock_is_running.return_value = True
+    
+    config_manager.stop_server_tmux_session("dev")
+    
+    assert mock_run.called
+    args = mock_run.call_args[0][0]
+    assert args == ["tmux", "kill-session", "-t", "microx_config_server_session_dev"]
+
+@patch("utils.config_manager.get_project_root")
+@patch("utils.config_manager.get_current_branch")
+@patch("utils.config_manager.start_server_in_tmux")
+def test_main_start_flag(mock_start_server, mock_get_branch, mock_get_root):
+    mock_get_root.return_value = "/root"
+    mock_get_branch.return_value = "main"
+    
+    # Mock sys.argv
+    with patch.object(sys, 'argv', ['prog', '--start']):
+        config_manager.main()
+        
+    mock_start_server.assert_called()
+


### PR DESCRIPTION
Improved modules/ollama_manager.py coverage from 39% to 71%.

Added tests/test_utils_config_manager.py, raising coverage from 0% to 63%.

Updated version to v0.0.1042, synced metadata, and updated changelog for v1041/v1042.